### PR TITLE
Xgb example

### DIFF
--- a/examples/search/xgb.py
+++ b/examples/search/xgb.py
@@ -1,0 +1,87 @@
+import pickle
+
+from skdist.distribute.search import DistGridSearchCV
+from sklearn.datasets import (
+  load_breast_cancer,
+  load_boston
+)
+from xgboost import (
+  XGBClassifier,
+  XGBRegressor
+)
+from pyspark.sql import SparkSession
+
+# spark session initialization
+spark = (
+    SparkSession
+    .builder
+    .getOrCreate()
+    )
+sc = spark.sparkContext
+
+### XGBClassifier ###
+
+# load sample data (binary target)
+data = load_breast_cancer()
+X = data["data"]
+y = data["target"]
+
+grid = dict(
+    learning_rate=[.05, .01],
+    max_depth=[4, 6, 8],
+  	colsample_bytree=[.6, .8, 1.0],
+    n_estimators=[100, 200, 300]
+)
+
+### distributed grid search
+model = DistGridSearchCV(
+    XGBClassifier(),
+    grid, sc, cv=5, scoring="roc_auc"
+    )
+# distributed fitting with spark
+model.fit(X,y)
+# predictions on the driver
+preds = model.predict(X)
+probs = model.predict_proba(X)
+
+# results
+print("-- Grid Search --")
+print("Best Score: {0}".format(model.best_score_))
+print("Best colsample_bytree: {0}".format(model.best_estimator_.colsample_bytree))
+print("Best learning_rate: {0}".format(model.best_estimator_.learning_rate))
+print("Best max_depth: {0}".format(model.best_estimator_.max_depth))
+print("Best n_estimators: {0}".format(model.best_estimator_.n_estimators))
+print(pickle.loads(pickle.dumps(model)))
+
+### XGBRegressor ###
+
+# load sample data (continuous target)
+data = load_boston()
+X = data["data"]
+y = data["target"]
+
+grid = dict(
+    learning_rate=[.05, .01],
+    max_depth=[4, 6, 8],
+  	colsample_bytree=[.6, .8, 1.0],
+    n_estimators=[100, 200, 300]
+)
+
+### distributed grid search
+model = DistGridSearchCV(
+    XGBRegressor(objective='reg:squarederror'),
+    grid, sc, cv=5, scoring="neg_mean_squared_error"
+    )
+# distributed fitting with spark
+model.fit(X,y)
+# predictions on the driver
+preds = model.predict(X)
+
+# results
+print("-- Grid Search --")
+print("Best Score: {0}".format(model.best_score_))
+print("Best colsample_bytree: {0}".format(model.best_estimator_.colsample_bytree))
+print("Best learning_rate: {0}".format(model.best_estimator_.learning_rate))
+print("Best max_depth: {0}".format(model.best_estimator_.max_depth))
+print("Best n_estimators: {0}".format(model.best_estimator_.n_estimators))
+print(pickle.loads(pickle.dumps(model)))

--- a/examples/search/xgb.py
+++ b/examples/search/xgb.py
@@ -13,6 +13,7 @@ trying to train multiple estimators in parallel. Skdist excels in this functiona
 leveraging DistGridSearchCV. In this example, we are able to train 54 unique sets of
 hyperparameters in parallel and return the the best model to the driver.
 
+NOTE: This example uses xgboost==0.90
 
 Here is a sample output run:
 

--- a/examples/search/xgb.py
+++ b/examples/search/xgb.py
@@ -98,6 +98,11 @@ sc = spark.sparkContext
 
 ### XGBClassifier ###
 
+# sklearn variables
+cv = 5
+clf_scoring = "roc_auc"
+reg_scoring = "neg_mean_squared_error"
+
 # load sample data (binary target)
 data = load_breast_cancer()
 X = data["data"]
@@ -113,7 +118,7 @@ grid = dict(
 ### distributed grid search
 model = DistGridSearchCV(
     XGBClassifier(),
-    grid, sc, cv=5, scoring="roc_auc"
+    grid, sc, cv=cv, scoring=clf_scoring
     )
 # distributed fitting with spark
 model.fit(X,y)
@@ -147,7 +152,7 @@ grid = dict(
 ### distributed grid search
 model = DistGridSearchCV(
     XGBRegressor(objective='reg:squarederror'),
-    grid, sc, cv=5, scoring="neg_mean_squared_error"
+    grid, sc, cv=cv, scoring=reg_scoring
     )
 # distributed fitting with spark
 model.fit(X,y)

--- a/examples/search/xgb.py
+++ b/examples/search/xgb.py
@@ -1,3 +1,80 @@
+"""
+====================================================================================
+Distribute hyperparameter tuning with gradient boosting trees via DistGridSearchCV
+====================================================================================
+
+In this example we train a classifier and regression with XGBoost by distributing
+the hyperparameter tuning through DistGridSearchCV. This should work right out of the
+box with XGBoost's sklearn wrapper.
+
+Given the sequential nature of training estimators on gradient boosting trees, it
+makes sense to distribute the hyperparameters and cross validation folds, rather than
+trying to train multiple estimators in parallel. Skdist excels in this functionality by
+leveraging DistGridSearchCV. In this example, we are able to train 54 unique sets of
+hyperparameters in parallel and return the the best model to the driver.
+
+
+Here is a sample output run:
+
+-- Grid Search --
+Best Score: 0.9936882800963308
+Best colsample_bytree: 1.0
+Best learning_rate: 0.05
+Best max_depth: 4
+Best n_estimators: 300
+DistGridSearchCV(cv=5, error_score='raise-deprecating',
+                 estimator=XGBClassifier(base_score=0.5, booster='gbtree',
+                                         colsample_bylevel=1,
+                                         colsample_bynode=1, colsample_bytree=1,
+                                         gamma=0, learning_rate=0.1,
+                                         max_delta_step=0, max_depth=3,
+                                         min_child_weight=1, missing=nan,
+                                         n_estimators=100, n_jobs=1,
+                                         nthread=None,
+                                         objective='binary:logistic',
+                                         random_state=0, reg_alpha=0,
+                                         reg_lambda=1, scale_pos_weight=1,
+                                         seed=None, silent=None, subsample=1,
+                                         verbosity=1),
+                 iid='warn', n_jobs=None,
+                 param_grid={'colsample_bytree': [0.6, 0.8, 1.0],
+                             'learning_rate': [0.05, 0.01],
+                             'max_depth': [4, 6, 8],
+                             'n_estimators': [100, 200, 300]},
+                 partitions='auto', pre_dispatch='2*n_jobs', preds=False,
+                 refit=True, return_train_score=False, sc=None,
+                 scoring='roc_auc', verbose=0)
+-- Grid Search --
+Best Score: -18.452273211144295
+Best colsample_bytree: 0.8
+Best learning_rate: 0.05
+Best max_depth: 4
+Best n_estimators: 200
+DistGridSearchCV(cv=5, error_score='raise-deprecating',
+                 estimator=XGBRegressor(base_score=0.5, booster='gbtree',
+                                        colsample_bylevel=1, colsample_bynode=1,
+                                        colsample_bytree=1, gamma=0,
+                                        importance_type='gain',
+                                        learning_rate=0.1, max_delta_step=0,
+                                        max_depth=3, min_child_weight=1,
+                                        missing=nan, n_estimators=100, n_jobs=1,
+                                        nthread=None,
+                                        objective='reg:squarederror',
+                                        random...
+                                        reg_lambda=1, scale_pos_weight=1,
+                                        seed=None, silent=None, subsample=1,
+                                        verbosity=1),
+                 iid='warn', n_jobs=None,
+                 param_grid={'colsample_bytree': [0.6, 0.8, 1.0],
+                             'learning_rate': [0.05, 0.01],
+                             'max_depth': [4, 6, 8],
+                             'n_estimators': [100, 200, 300]},
+                 partitions='auto', pre_dispatch='2*n_jobs', preds=False,
+                 refit=True, return_train_score=False, sc=None,
+                 scoring='neg_mean_squared_error', verbose=0)
+"""
+print(__doc__)
+
 import pickle
 
 from skdist.distribute.search import DistGridSearchCV
@@ -29,7 +106,7 @@ y = data["target"]
 grid = dict(
     learning_rate=[.05, .01],
     max_depth=[4, 6, 8],
-  	colsample_bytree=[.6, .8, 1.0],
+    colsample_bytree=[.6, .8, 1.0],
     n_estimators=[100, 200, 300]
 )
 
@@ -63,7 +140,7 @@ y = data["target"]
 grid = dict(
     learning_rate=[.05, .01],
     max_depth=[4, 6, 8],
-  	colsample_bytree=[.6, .8, 1.0],
+    colsample_bytree=[.6, .8, 1.0],
     n_estimators=[100, 200, 300]
 )
 

--- a/skdist/__init__.py
+++ b/skdist/__init__.py
@@ -1,18 +1,18 @@
 """
 Distributed scikit-learn meta-estimators in PySpark
 ===================================================
-skdist is a Python module that aims to efficiently distribute scikit-learn 
-meta-estimator model fitting with PySpark. Where sklearn uses joblib to 
-parallelize these operations, distml uses spark, enabling effectively infinite 
-parallelization, unconstrained by the number of cores on a single machine. 
+skdist is a Python module that aims to efficiently distribute scikit-learn
+meta-estimator model fitting with PySpark. Where sklearn uses joblib to
+parallelize these operations, distml uses spark, enabling effectively infinite
+parallelization, unconstrained by the number of cores on a single machine.
 
-Existing scikit-learn meta-estimators for model selection, ensembling, 
-multiclass fitting, and feature unioning are inherited, and have their fit methods 
-overridden with a distributed implementation using spark. The resulting fitted model 
-is effectively identical to its single machine counterpart, 
+Existing scikit-learn meta-estimators for model selection, ensembling,
+multiclass fitting, and feature unioning are inherited, and have their fit methods
+overridden with a distributed implementation using spark. The resulting fitted model
+is effectively identical to its single machine counterpart,
 ready for prediction using the inherited methods.
 """
 
-__version__ = '0.1.0'
+__version__ = '0.1.01'
 
 __all__ = ['distribute', 'preprocessing', 'postprocessing', 'tests']

--- a/skdist/__init__.py
+++ b/skdist/__init__.py
@@ -13,6 +13,6 @@ is effectively identical to its single machine counterpart,
 ready for prediction using the inherited methods.
 """
 
-__version__ = '0.1.01'
+__version__ = '0.1.0'
 
 __all__ = ['distribute', 'preprocessing', 'postprocessing', 'tests']


### PR DESCRIPTION
This PR address the following [issue](https://github.com/Ibotta/sk-dist/issues/3), and documents support for `Xgboost` models via `DistGridSearchCV`. Given the sequential nature of GBTs, it is best to distribute the searching of hyperparameters of the model, and `skdist` excels in this functionality. See below for stdout of a working example:

```
-- Grid Search --
Best Score: 0.9936882800963308
Best colsample_bytree: 1.0
Best learning_rate: 0.05
Best max_depth: 4
Best n_estimators: 300
DistGridSearchCV(cv=5, error_score='raise-deprecating',
                 estimator=XGBClassifier(base_score=0.5, booster='gbtree',
                                         colsample_bylevel=1,
                                         colsample_bynode=1, colsample_bytree=1,
                                         gamma=0, learning_rate=0.1,
                                         max_delta_step=0, max_depth=3,
                                         min_child_weight=1, missing=nan,
                                         n_estimators=100, n_jobs=1,
                                         nthread=None,
                                         objective='binary:logistic',
                                         random_state=0, reg_alpha=0,
                                         reg_lambda=1, scale_pos_weight=1,
                                         seed=None, silent=None, subsample=1,
                                         verbosity=1),
                 iid='warn', n_jobs=None,
                 param_grid={'colsample_bytree': [0.6, 0.8, 1.0],
                             'learning_rate': [0.05, 0.01],
                             'max_depth': [4, 6, 8],
                             'n_estimators': [100, 200, 300]},
                 partitions='auto', pre_dispatch='2*n_jobs', preds=False,
                 refit=True, return_train_score=False, sc=None,
                 scoring='roc_auc', verbose=0)
-- Grid Search --
Best Score: -18.452273211144295
Best colsample_bytree: 0.8
Best learning_rate: 0.05
Best max_depth: 4
Best n_estimators: 200
DistGridSearchCV(cv=5, error_score='raise-deprecating',
                 estimator=XGBRegressor(base_score=0.5, booster='gbtree',
                                        colsample_bylevel=1, colsample_bynode=1,
                                        colsample_bytree=1, gamma=0,
                                        importance_type='gain',
                                        learning_rate=0.1, max_delta_step=0,
                                        max_depth=3, min_child_weight=1,
                                        missing=nan, n_estimators=100, n_jobs=1,
                                        nthread=None,
                                        objective='reg:squarederror',
                                        random...
                                        reg_lambda=1, scale_pos_weight=1,
                                        seed=None, silent=None, subsample=1,
                                        verbosity=1),
                 iid='warn', n_jobs=None,
                 param_grid={'colsample_bytree': [0.6, 0.8, 1.0],
                             'learning_rate': [0.05, 0.01],
                             'max_depth': [4, 6, 8],
                             'n_estimators': [100, 200, 300]},
                 partitions='auto', pre_dispatch='2*n_jobs', preds=False,
                 refit=True, return_train_score=False, sc=None,
                 scoring='neg_mean_squared_error', verbose=0)
```