### PR TITLE
Fix module name in basic_usage example

### DIFF
--- a/examples/eliminate/basic_usage.py
+++ b/examples/eliminate/basic_usage.py
@@ -34,7 +34,7 @@ print(__doc__)
 import time
 import numpy as np
 
-from skdist.distribute.select import DistFeatureEliminator
+from skdist.distribute.eliminate import DistFeatureEliminator
 from sklearn.feature_selection import RFECV
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.datasets import make_classification


### PR DESCRIPTION
## Eliminate Module Example Fix
This is a hotfix for the `eliminate` module example. After changing the name of the module to `eliminate` from `select`, this example import was left behind.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added reviewers to the PR.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
