### PR TITLE
allowing Encoderizer to identify tuple type columns and assign multih…

### DIFF
--- a/skdist/__init__.py
+++ b/skdist/__init__.py
@@ -13,6 +13,6 @@ is effectively identical to its single machine counterpart,
 ready for prediction using the inherited methods.
 """
 
-__version__ = '0.1.3'
+__version__ = '0.1.4'
 
 __all__ = ['distribute', 'preprocessing', 'postprocessing', 'tests']

--- a/skdist/distribute/encoder.py
+++ b/skdist/distribute/encoder.py
@@ -307,6 +307,25 @@ class Encoderizer(FeatureUnion):
             raise ValueError("Convert this column to list before fitting: {0}".format(col_name))
         return isinstance(col, list)
 
+    @staticmethod
+    def _is_tuple(col, col_name):
+        """Check if numpy array contains tuples of strings, if string attempt to conver to tuple"""
+        col = col.values
+        i=0 
+        while col[i] is None:
+            i+=1
+        col = col[i]
+        raise_exception = False
+        if isinstance(col, str):
+            try:
+                ast.literal_eval(col)
+                raise_exception = True
+            except:
+                return False
+        if raise_exception:
+            raise ValueError("Convert this column to tuple before fitting: {0}".format(col_name))
+        return isinstance(col, tuple)
+
     def _infer_column(self, col_name, X, _default_encoders, thresh=0.10):
         """ Infer encoder type of individual DataFrame column """
         if np.all(X.values == None):
@@ -319,6 +338,10 @@ class Encoderizer(FeatureUnion):
 
         is_list = self._is_list(X, col_name)
         if is_list:
+            return _default_encoders[self.size]["multihotencoder"](col_name)
+
+        is_tuple = self._is_tuple(X, col_name)
+        if is_tuple:
             return _default_encoders[self.size]["multihotencoder"](col_name)
         
         try:

--- a/skdist/distribute/tests/test_encoder.py
+++ b/skdist/distribute/tests/test_encoder.py
@@ -60,3 +60,24 @@ def test_dict_list():
     encoderizer = encoder.Encoderizer(size="medium")
     X_t = encoderizer.fit_transform(df)
     assert X_t.shape == (12, 210)
+
+def test_dict_list_tuple():
+    # pandas encoderizer example
+    X = [
+        "[text encoding is fun]",
+        "this is a text encoding {'pizza': 'example'}",
+        "hopefully it works and [we'll have passed] the test"
+        ]
+    df = pd.DataFrame({
+	    "text_col": X*4,
+	    "categorical_str_col": ["control", "treatment", "control"]*4,
+	    "categorical_int_col": [0, 1, 2]*4,
+	    "numeric_col": [5, 22, 69]*4,
+	    "dict_col": [{"a": 4}, {"b": 1}, {"c": 3}]*4,
+	    "list_col": [[1, 2], [1, 3], [2,]]*4,
+	    "tuple_col": [(1, 2), (1, 3), (2,)]*4
+	    })
+    encoderizer = encoder.Encoderizer(size="medium")
+    X_t = encoderizer.fit_transform(df)
+    assert X_t.shape == (12, 244)
+    


### PR DESCRIPTION
…otencoder

## Handle tuple columns with Encoderizer

### Description
Adding `_is_tuple()` function to allow `_infer_column()` to identify tuple type in column and use `multihotencoder` for transformation.  Also adding `test_dict_list_tuple()` to ensure the update works.  @denver1117 should this include a version bump?

### Motivation and Context
This update solves the problem where a tuple type column breaks the fitting of an encoder without a config specifying the desired encoding type: `AttributeError: 'tuple' object has no attribute 'lower'`.  Now the tuple column is assigned a `multihotencoder`, similar to a column of lists.

### How Has This Been Tested?
Tested locally.
https://travis-ci.org/Ibotta/sk-dist/builds/594807844?utm_source=github_status&utm_medium=notification

### Screenshots (if appropriate):

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added reviewers to the PR.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
