### PR TITLE
Fix label encoder bug

### DIFF
--- a/skdist/postprocessing.py
+++ b/skdist/postprocessing.py
@@ -86,7 +86,7 @@ class SimpleVoter(BaseEstimator, ClassifierMixin):
         
     def _predict(self, X):
         "" "Collect results from clf.predict calls """
-        return np.asarray([clf.predict(X) for clf in self.estimators_]).T
+        return np.asarray([self.le_.transform(clf.predict(X)) for clf in self.estimators_]).T
         
     def _predict_proba(self, X):
         """ Predict class probabilities for X in 'soft' voting """

--- a/skdist/tests/test_postprocessing.py
+++ b/skdist/tests/test_postprocessing.py
@@ -44,4 +44,20 @@ def test_predict_hard_voting():
         voting="hard", classes=model1.classes_
         )
     pred = clf.predict(X)
-    assert pred.shape == y.shape
+    assert np.allclose(pred, y)
+
+def test_predict_strings():
+    X = np.array([[1,2,3], [4,5,6]])
+    y = np.array(["pizza","tacos"])
+
+    model1 = LogisticRegression(solver="liblinear")
+    model2 = LogisticRegression(solver="lbfgs")
+    model1.fit(X,y)
+    model2.fit(X,y)
+
+    clf = postprocessing.SimpleVoter(
+        [("model1", model1), ("model2", model2)],
+        voting="hard", classes=model1.classes_
+        )
+    pred = clf.predict(X)
+    assert list(pred) == list(y)


### PR DESCRIPTION
## Fix Label Encoder Bug in SimpleVoter

### Description
SimpleVoter previously improperly implemented using the label encoder. This only revealed itself through hard voting where the `y` contains string values. This was not previously tested.

### Motivation and Context
Bug introduced with this issue: https://github.com/Ibotta/sk-dist/issues/18

### How Has This Been Tested?
Additional unit tests have been added to the test suite which test both integer and string valued response variables for SimpleVoter

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added reviewers to the PR.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
