### PR TITLE
Add max sklearn version

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,7 @@ Dependencies
 ``sk-dist`` requires:
 
 -  `Python <https://www.python.org/>`__ (>= 3.5)
--  `scikit-learn <https://scikit-learn.org/stable/>`__ (>=0.20.0)
+-  `scikit-learn <https://scikit-learn.org/stable/>`__ (>=0.20.0,<0.23.2)
 -  `pandas <https://pandas.pydata.org/>`__ (>=0.17.0)
 -  `numpy <https://www.numpy.org/>`__ 
 -  `scipy <https://www.scipy.org/>`__ 

--- a/setup.py
+++ b/setup.py
@@ -27,13 +27,14 @@ PROJECT_URLS = {"Source Code": "https://github.com/Ibotta/sk-dist"}
 MIN_PYTHON_VERSION = "3.5"
 MIN_PANDAS_VERSION = "0.17.0"
 MIN_SKLEARN_VERSION = "0.20.0"
+MAX_SKLEARN_VERSION = "0.23.2"
 MIN_XGBOOST_VERSION = "0.4"
 PYARROW_VERSION = "0.16.0"
 MIN_PYSPARK_VERSION = "2.4.4"
 MIN_PYTESTSPARK_VERSION = "0.4.5"
 
 install_requires = [
-    "scikit-learn>={0}".format(MIN_SKLEARN_VERSION),
+    "scikit-learn>={0},<{1}".format(MIN_SKLEARN_VERSION, MAX_SKLEARN_VERSION),
     "pandas>={0}".format(MIN_PANDAS_VERSION),
     "numpy",
     "scipy",

--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ DOWNLOAD_URL = "https://pypi.org/project/sk-dist/#files"
 PROJECT_URLS = {"Source Code": "https://github.com/Ibotta/sk-dist"}
 MIN_PYTHON_VERSION = "3.5"
 MIN_PANDAS_VERSION = "0.17.0"
+MIN_NUMPY_VERSION = "1.16.5"
 MIN_SKLEARN_VERSION = "0.20.0"
 MAX_SKLEARN_VERSION = "0.23.2"
 MIN_XGBOOST_VERSION = "0.4"
@@ -36,7 +37,7 @@ MIN_PYTESTSPARK_VERSION = "0.4.5"
 install_requires = [
     "scikit-learn>={0},<{1}".format(MIN_SKLEARN_VERSION, MAX_SKLEARN_VERSION),
     "pandas>={0}".format(MIN_PANDAS_VERSION),
-    "numpy",
+    "numpy>={0}".format(MIN_NUMPY_VERSION),
     "scipy",
     "joblib",
 ]


### PR DESCRIPTION
## Add max sklearn version

### Description
Adds a maximum sklearn version

### Motivation and Context
`sklearn` 0.24 is live and causes issues with forest ensemble compatibility. This is a temporary solve until further work is done for 0.24 compatibility 

### How Has This Been Tested?
[Travis build passed](https://travis-ci.org/github/Ibotta/sk-dist/builds/752048959)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [x] I have added reviewers to the PR.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
